### PR TITLE
Add Star Ratings

### DIFF
--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -37,36 +37,6 @@ class GlobalEvent(Base):
 
 class Player(Base):
 
-    @staticmethod
-    def _rating_to_stars(val):
-        return 0.5 * (round(val * 10))
-
-    @property
-    def batting_stars(self):
-        return self._rating_to_stars(((1 - self.tragicness) ** 0.01) * ((1 - self.patheticism) ** 0.05) *
-                                     ((self.thwackability * self.divinity) ** 0.35) *
-                                     ((self.moxie * self.musclitude) ** 0.075) * (self.martyrdom ** 0.02))
-
-    @property
-    def pitching_stars(self):
-        return self._rating_to_stars((self.unthwackability ** 0.5) * (self.ruthlessness ** 0.4) *
-                                     (self.overpowerment ** 0.15) * (self.shakespearianism ** 0.1) *
-                                     (self.coldness ** 0.025))
-
-    @property
-    def baserunning_stars(self):
-        return self._rating_to_stars((self.laserlikeness**0.5) *
-                                     ((self.continuation * self.base_thirst * self.indulgence * self.ground_friction) ** 0.1))
-
-    @property
-    def defense_stars(self):
-        return self._rating_to_stars(((self.omniscience * self.tenaciousness) ** 0.2) *
-                                     ((self.watchfulness * self.anticapitalism * self.chasiness) ** 0.1))
-
-    def get_vibe(self, day):
-        return 0.5 * ((self.pressurization + self.cinnamon) * math.cos((math.pi * day) / (5 * self.buoyancy + 3)) -
-                      self.pressurization + self.cinnamon)
-
     @classmethod
     def load(cls, *ids):
         """
@@ -83,6 +53,51 @@ class Player(Base):
         Load single player.
         """
         return cls.load(id_).get(id_)
+
+    @property
+    def batting_rating(self):
+        return (((1 - self.tragicness) ** 0.01) * ((1 - self.patheticism) ** 0.05) *
+                ((self.thwackability * self.divinity) ** 0.35) *
+                ((self.moxie * self.musclitude) ** 0.075) * (self.martyrdom ** 0.02))
+
+    @property
+    def pitching_rating(self):
+        return ((self.unthwackability ** 0.5) * (self.ruthlessness ** 0.4) *
+                (self.overpowerment ** 0.15) * (self.shakespearianism ** 0.1) * (self.coldness ** 0.025))
+
+    @property
+    def baserunning_rating(self):
+        return ((self.laserlikeness**0.5) *
+                ((self.continuation * self.base_thirst * self.indulgence * self.ground_friction) ** 0.1))
+
+    @property
+    def defense_rating(self):
+        return (((self.omniscience * self.tenaciousness) ** 0.2) *
+                ((self.watchfulness * self.anticapitalism * self.chasiness) ** 0.1))
+
+    @staticmethod
+    def _rating_to_stars(val):
+        return 0.5 * (round(val * 10))
+
+    @property
+    def batting_stars(self):
+        return self._rating_to_stars(self.batting_rating)
+
+    @property
+    def pitching_stars(self):
+        return self._rating_to_stars(self.pitching_rating)
+
+    @property
+    def baserunning_stars(self):
+        return self._rating_to_stars(self.baserunning_rating)
+
+    @property
+    def defense_stars(self):
+        return self._rating_to_stars(self.defense_rating)
+
+    def get_vibe(self, day):
+        return 0.5 * ((self.pressurization + self.cinnamon) * math.cos((math.pi * day) / (5 * self.buoyancy + 3)) -
+                      self.pressurization + self.cinnamon)
 
 
 class Team(Base):


### PR DESCRIPTION
Splits the star calculation into Ratings and Stars: stars are what's on the site, rating is the unrounded representation between 0-1. I'm pretty sure the site uses the rating to compare stats for blessings (best hitter, etc), so this is helpful when trying to get that info.

Also moved all the getters/setters under the load functions, to keep it consistent with the other classes.