### PR TITLE
Add Playoffs & Election

### DIFF
--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -418,7 +418,7 @@ class BlessingResult(Base):
         return self.bonus_id
 
 
-class OffseasonResult(Base):
+class ElectionResult(Base):
 
     @classmethod
     def load_by_season(cls, season):
@@ -460,4 +460,76 @@ class OffseasonResult(Base):
         self._decree_results_ids = value
 
 
-# TODO offseason setup and playoff stuff
+class Playoff(Base):
+
+    @classmethod
+    def load_by_season(cls, season):
+        playoff = database.get_playoff_details(season)
+        return cls(playoff)
+
+    @property
+    def rounds(self):
+        if self._rounds:
+            return self._rounds
+        self._rounds = [PlayoffRound.load(id_) for id_ in self._rounds_ids]
+        return self._rounds
+
+    @rounds.setter
+    def rounds(self, value):
+        self._rounds = None
+        self._rounds_ids = value
+
+    @property
+    def winner(self):
+        if self._winner:
+            return self._winner
+        self._winner = Team.load(self._winner_id)
+        return self._winner
+
+    @winner.setter
+    def winner(self, value):
+        self._winner = None
+        self._winner_id = value
+
+
+class PlayoffRound(Base):
+
+    @classmethod
+    def load(cls, id_):
+        round = database.get_playoff_round(id_)
+        return cls(round)
+
+    # TODO: Getting game ids for all of these is probably a bad idea, do individual lookups instead
+    @property
+    def games(self):
+        if self._games:
+            return self._games
+        self._games = []
+        for day in self._games_ids:
+            self._games.append([Game.load_by_id(id_) for id_ in day if id_ != "none"])
+        return self._games
+
+    @games.setter
+    def games(self, value):
+        self._games = None
+        self._games_ids = value
+
+    @property
+    def winners(self):
+        if self._winners:
+            return self._winners
+        self._winners = [Team.load(x) for x in self._winners_ids]
+        return self._winners
+
+    @winners.setter
+    def winners(self, value):
+        self._winners = None
+        self._winners_ids = value
+
+
+class Election(Base):
+
+    @classmethod
+    def load(cls):
+        offseason = database.get_offseason_election_details()
+        return cls(offseason)


### PR DESCRIPTION
Also renames OffseasonResults to ElectionResults, seems clearer to me

The Playoff Round Game lazy loading ends up calling the endpoint for each game separately (only supports one ID), and there could be up to 20 games in a single round, which isn't great. I'd like to only grab the game info if you ask for that specific game or day in the series to reduce database calls.