### PR TITLE
Fix Vibe equation (again)

### DIFF
--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -99,7 +99,8 @@ class Player(Base):
         """
         Day is 1-indexed
         """
-        return 0.5 * ((self.pressurization + self.cinnamon) * math.cos((math.pi * (day-1)) / (5 * self.buoyancy + 3)) -
+        return 0.5 * ((self.pressurization + self.cinnamon) *
+                      math.sin(math.pi * (2 / (6 + round(10 * self.buoyancy)) * (day - 1) + 0.5)) -
                       self.pressurization + self.cinnamon)
 
     @property


### PR DESCRIPTION
Based on discussion in the SIBR discord #math channel, the vibe equation in baronbliss's sheet seems to be incorrect. This updates the equation to what is found in the site JavaScript directly, and has been tested to be correct for all the teams in the Season 5 playoffs for day 100.