### PR TITLE
Implement Soulscream

### DIFF
--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -105,6 +105,22 @@ class Player(Base):
                       self.pressurization + self.cinnamon)
 
     @property
+    def soulscream(self):
+        letters = ["A", "E", "I", "O", "U", "X", "H", "A", "E", "I"]
+        stats = [self.pressurization, self.divinity, self.tragicness, self.shakespearianism, self.ruthlessness]
+
+        scream = []
+        for r in range(self.soul):
+            sub_scream = []
+            i = 10 ** -r
+            for s in stats:
+                c = math.floor((s % i) / i * 10)
+                sub_scream.append(letters[c])
+            scream.extend(sub_scream + sub_scream + [sub_scream[0]])
+
+        return ''.join(scream)
+
+    @property
     def blood(self):
         return tables.Blood(self._blood)
 


### PR DESCRIPTION
Closes #24 

I simplified the equation from the Javascript in 2 main ways:
1. The equation runs through the 5 applicable stats more than once, and as such the letters repeat (Groups of 11 letters, repeat every 5). Because of this we now only calculate the first 5 letters and just duplicate them rather than running through the math again.
2. Changed to 10^-x rather than 1 / (10^x) since they're equivalent

Tested it's correct on the top 10 of the current Idol board (pre S6 election). We probably need to test it on some of the incinerated players, since they have known bugs that cause it to error. 