### PR TITLE
Idol fixes

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -1081,7 +1081,6 @@ class Tiebreaker(Base):
 
 
 class Idol(Base):
-    _player = None
 
     @classmethod
     def load(cls):
@@ -1093,7 +1092,7 @@ class Idol(Base):
 
     @property
     def player(self):
-        if self._player:
+        if getattr(self, '_player', None):
             return self._player
         self._player = Player.load_one(self.player_id)
         return self._player

--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -1081,13 +1081,14 @@ class Tiebreaker(Base):
 
 
 class Idol(Base):
+    _player = None
 
     @classmethod
     def load(cls):
         idols = database.get_idols()
         idols_dict = OrderedDict()
         for idol in idols:
-            idols_dict[idol['id']] = cls(idol)
+            idols_dict[idol['playerId']] = cls(idol)
         return idols_dict
 
     @property


### PR DESCRIPTION
When TGB removed idol player counts they also removed the idol IDs, so key the dict against the playerId instead. This also fixes a bug when loading a player, since self._player was previously undefined.