### PR TITLE
Fix simulated copy to account for new backend ratings

### DIFF
--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -392,6 +392,12 @@ class Player(Base):
             elif r_key in original_json:
                 original_json[r_key] = random.uniform(0.01, 0.99)
 
+        # Clear database-provided ratings to force a recalculation
+        original_json['hittingRating'] = None
+        original_json['pitchingRating'] = None
+        original_json['baserunningRating'] = None
+        original_json['defenseRating'] = None
+
         return Player(original_json)
 
 


### PR DESCRIPTION
The new ratings from the database were copied to the new simulated player, so calls to get the rating/stars were using that instead of calculating what it should be with the new attributes. This just clears the keys when generating the new player JSON.