### PR TITLE
Add Chronicler endpoints

### DIFF
--- a/blaseball_mike/chronicler.py
+++ b/blaseball_mike/chronicler.py
@@ -1,0 +1,126 @@
+"""Client for chronicler APIs
+
+API Reference (out of date): https://astrid.stoplight.io/docs/sibr/reference/Chronicler.v1.yaml
+"""
+import requests
+from datetime import datetime
+
+BASE_URL = 'https://api.sibr.dev/chronicler/v1'
+TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def prepare_id(id_):
+    """if id_ is string uuid, return as is, if list, format as comma separated list."""
+    if isinstance(id_, list):
+        return ','.join(id_)
+    elif isinstance(id_, str):
+        return id_
+    else:
+        raise ValueError(f'Incorrect ID type: {type(id_)}')
+
+
+def paged_get(url, params):
+    data = []
+    while(True):
+        res = requests.get(url, params=params)
+        out = res.json()
+        d = out.get("data", [])
+        page = out.get("nextPage")
+        
+        data.extend(d)
+        if page is None or len(d) == 0 or params.get("count", 1000) >= len(d):
+            break
+        params["page"] = page
+
+    return data
+
+
+def get_games(season=None, day=None, team_ids=None, pitcher_ids=None, weather=None, started=None, finished=None, outcomes=None, order=None, count=None):
+    params = {}
+    if season:
+        params["season"] = season - 1
+    if day:
+        params["day"] = day - 1
+    if order:
+        params["order"] = order
+    if count:
+        params["count"] = count
+    if team_ids:
+        params["team"] = prepare_id(team_ids)
+    if pitcher_ids:
+        params["pitcher"] = prepare_id(pitcher_ids)
+    if started:
+        params["started"] = started
+    if finished:
+        params["finished"] = finished
+    if outcomes:
+        params["outcomes"] = outcomes
+    if weather:
+        params["weather"] = weather
+
+    data = paged_get(f'{BASE_URL}/games', params=params)
+    return {p['gameId']: p for p in data}
+
+
+def get_player_updates(ids=None, before=None, after=None, order=None, count=None):
+    if isinstance(before, datetime):
+        before = before.strftime(TIMESTAMP_FORMAT)
+    if isinstance(after, datetime):
+        after = after.strftime(TIMESTAMP_FORMAT)
+
+    params = {}
+    if before:
+        params["before"] = before
+    if after:
+        params["after"] = after
+    if order:
+        params["order"] = order
+    if count:
+        params["count"] = count
+    if ids:
+        params["player"] = prepare_id(ids)
+
+    data = paged_get(f'{BASE_URL}/players/updates', params=params)
+    return {p['playerId']: p for p in data}
+
+
+def get_team_updates(ids=None, before=None, after=None, order=None, count=None):
+    if isinstance(before, datetime):
+        before = before.strftime(TIMESTAMP_FORMAT)
+    if isinstance(after, datetime):
+        after = after.strftime(TIMESTAMP_FORMAT)
+
+    params = {}
+    if before:
+        params["before"] = before
+    if after:
+        params["after"] = after
+    if order:
+        params["order"] = order
+    if count:
+        params["count"] = count
+    if ids:
+        params["team"] = prepare_id(ids)
+
+    data = paged_get(f'{BASE_URL}/teams/updates', params=params)
+    return {p['teamId']: p for p in data}
+
+
+def get_tribute_updates(before=None, after=None, order=None, count=None):
+    if isinstance(before, datetime):
+        before = before.strftime(TIMESTAMP_FORMAT)
+    if isinstance(after, datetime):
+        after = after.strftime(TIMESTAMP_FORMAT)
+
+    params = {}
+    if before:
+        params["before"] = before
+    if after:
+        params["after"] = after
+    if order:
+        params["order"] = order
+    if count:
+        params["count"] = count
+
+    data = paged_get(f'{BASE_URL}/tributes/hourly', params=params)
+    return {p['timestamp']: p for p in data}


### PR DESCRIPTION
Added for access to historical data and to reduce network calls in some instances. I'm up for adding/removing/renaming some of the functions here if needed.

### Team.load_at_time, Player.load_at_time & Tribute.load_at_time
Allows loading a team/player as they appeared at a particular point in time, timestamp is saved so that future lazy-loading is also at that point in time. Ideally this would be by Gameday, but Astrid's still working on the mapping.
```python
# Loads the S2 Tigers
end_of_s2= datetime(month=8, day=1, year=2020, hour=18)
team = Team.load_at_time("747b8e4a-7e50-4638-a973-ea7950a3e739", end_of_s2)
    for x in team.lineup:
        print(x.name, x.batting_stars)
    print("----------------")
    for x in team.rotation:
        print(x.name, x.pitching_stars)
```

### Game.load_by_season
Currently games can only be loaded one day at a time or by game ID, so getting multiple games requires a lot of network calls. This adds support for loading an entire season's worth (optionally filtered by team).