### PR TITLE
Fix chronicler games endpoint for Coffee Cup

### DIFF
--- a/blaseball_mike/chronicler.py
+++ b/blaseball_mike/chronicler.py
@@ -41,7 +41,7 @@ def paged_get(url, params, session=None):
 
 def get_games(season=None, day=None, team_ids=None, pitcher_ids=None, weather=None, started=None, finished=None, outcomes=None, order=None, count=None):
     params = {}
-    if season:
+    if season is not None:
         params["season"] = season - 1
     if day:
         params["day"] = day - 1


### PR DESCRIPTION
The Chronicler endpoint for games (used for Game.load_by_season) is currently ignoring the `season` argument when 0, which means requests to get the current Coffee Cup games instead returns a list of every game ever played.