### PR TITLE
Add Time Mapping

### DIFF
--- a/docs/blaseball_mike/chronicler.html
+++ b/docs/blaseball_mike/chronicler.html
@@ -162,7 +162,31 @@ def get_tribute_updates(before=None, after=None, order=None, count=None):
     if count:
         params[&#34;count&#34;] = count
 
-    return paged_get(f&#39;{BASE_URL}/tributes/hourly&#39;, params=params, session=cached_session)</code></pre>
+    return paged_get(f&#39;{BASE_URL}/tributes/hourly&#39;, params=params, session=cached_session)
+
+def time_map(season=0, tournament=-1, day=0, include_nongame=False):
+    &#34;&#34;&#34;
+    Map a season/day to a real-life timestamp
+
+    Returns a list of dictionaries containing time information
+    &#34;&#34;&#34;
+    season = season - 1
+    day = day - 1
+
+    map = cached_session.get(f&#39;{BASE_URL}/time/map&#39;).json()
+
+    # Filter out desired events
+    if tournament != -1:
+        # Season is not always -1 if a tournament is active, so ignore it
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == tournament and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+    else:
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == -1 and x[&#39;season&#39;] == season and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+
+    # Optionally filter out phase-change events
+    if not include_nongame:
+        results = list(filter(lambda x: x[&#39;type&#39;] in (&#39;season&#39;, &#39;tournament&#39;, &#39;postseason&#39;), results))
+
+    return results</code></pre>
 </details>
 </section>
 <section>
@@ -350,6 +374,41 @@ def get_tribute_updates(before=None, after=None, order=None, count=None):
         raise ValueError(f&#39;Incorrect ID type: {type(id_)}&#39;)</code></pre>
 </details>
 </dd>
+<dt id="blaseball_mike.chronicler.time_map"><code class="name flex">
+<span>def <span class="ident">time_map</span></span>(<span>season=0, tournament=-1, day=0, include_nongame=False)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Map a season/day to a real-life timestamp</p>
+<p>Returns a list of dictionaries containing time information</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def time_map(season=0, tournament=-1, day=0, include_nongame=False):
+    &#34;&#34;&#34;
+    Map a season/day to a real-life timestamp
+
+    Returns a list of dictionaries containing time information
+    &#34;&#34;&#34;
+    season = season - 1
+    day = day - 1
+
+    map = cached_session.get(f&#39;{BASE_URL}/time/map&#39;).json()
+
+    # Filter out desired events
+    if tournament != -1:
+        # Season is not always -1 if a tournament is active, so ignore it
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == tournament and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+    else:
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == -1 and x[&#39;season&#39;] == season and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+
+    # Optionally filter out phase-change events
+    if not include_nongame:
+        results = list(filter(lambda x: x[&#39;type&#39;] in (&#39;season&#39;, &#39;tournament&#39;, &#39;postseason&#39;), results))
+
+    return results</code></pre>
+</details>
+</dd>
 </dl>
 </section>
 <section>
@@ -374,6 +433,7 @@ def get_tribute_updates(before=None, after=None, order=None, count=None):
 <li><code><a title="blaseball_mike.chronicler.get_tribute_updates" href="#blaseball_mike.chronicler.get_tribute_updates">get_tribute_updates</a></code></li>
 <li><code><a title="blaseball_mike.chronicler.paged_get" href="#blaseball_mike.chronicler.paged_get">paged_get</a></code></li>
 <li><code><a title="blaseball_mike.chronicler.prepare_id" href="#blaseball_mike.chronicler.prepare_id">prepare_id</a></code></li>
+<li><code><a title="blaseball_mike.chronicler.time_map" href="#blaseball_mike.chronicler.time_map">time_map</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/blaseball_mike/tables.html
+++ b/docs/blaseball_mike/tables.html
@@ -50,6 +50,7 @@ class Weather(Enum):
     BLACK_HOLE = 14, &#34;Black Hole&#34;
     COFFEE = 15, &#34;Coffee&#34;
     COFFEE_2 = 16, &#34;Coffee 2&#34;
+    COFFEE_3S = 17, &#34;Coffee 3s&#34;
 
     @classmethod
     def _missing_(cls, value):
@@ -275,6 +276,7 @@ class Tarot(Enum):
     BLACK_HOLE = 14, &#34;Black Hole&#34;
     COFFEE = 15, &#34;Coffee&#34;
     COFFEE_2 = 16, &#34;Coffee 2&#34;
+    COFFEE_3S = 17, &#34;Coffee 3s&#34;
 
     @classmethod
     def _missing_(cls, value):
@@ -315,6 +317,10 @@ class Tarot(Enum):
 <div class="desc"></div>
 </dd>
 <dt id="blaseball_mike.tables.Weather.COFFEE_2"><code class="name">var <span class="ident">COFFEE_2</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.Weather.COFFEE_3S"><code class="name">var <span class="ident">COFFEE_3S</span></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -419,6 +425,7 @@ class Tarot(Enum):
 <li><code><a title="blaseball_mike.tables.Weather.BLOODRAIN" href="#blaseball_mike.tables.Weather.BLOODRAIN">BLOODRAIN</a></code></li>
 <li><code><a title="blaseball_mike.tables.Weather.COFFEE" href="#blaseball_mike.tables.Weather.COFFEE">COFFEE</a></code></li>
 <li><code><a title="blaseball_mike.tables.Weather.COFFEE_2" href="#blaseball_mike.tables.Weather.COFFEE_2">COFFEE_2</a></code></li>
+<li><code><a title="blaseball_mike.tables.Weather.COFFEE_3S" href="#blaseball_mike.tables.Weather.COFFEE_3S">COFFEE_3S</a></code></li>
 <li><code><a title="blaseball_mike.tables.Weather.FEEDBACK" href="#blaseball_mike.tables.Weather.FEEDBACK">FEEDBACK</a></code></li>
 <li><code><a title="blaseball_mike.tables.Weather.GLITTER" href="#blaseball_mike.tables.Weather.GLITTER">GLITTER</a></code></li>
 <li><code><a title="blaseball_mike.tables.Weather.INVALID" href="#blaseball_mike.tables.Weather.INVALID">INVALID</a></code></li>


### PR DESCRIPTION
Provides a function for transforming Season/Day or Tournament/Day into a real life timestamp for use in historical pull functions. I'm not sure how exactly to wrap this into the model API, so I'm just leaving it as a chronicler fetch function for now