### PR TITLE
Add Fight support

### DIFF
--- a/blaseball_mike/chronicler.py
+++ b/blaseball_mike/chronicler.py
@@ -135,6 +135,7 @@ def get_tribute_updates(before=None, after=None, order=None, count=None):
 
     return paged_get(f'{BASE_URL}/tributes/hourly', params=params, session=cached_session)
 
+
 def time_map(season=0, tournament=-1, day=0, include_nongame=False):
     """
     Map a season/day to a real-life timestamp
@@ -164,3 +165,18 @@ def time_map(season=0, tournament=-1, day=0, include_nongame=False):
             result["endTime"] = parse(result["endTime"])
 
     return results
+
+
+def get_fights(id_=None, season=0):
+    """
+    Return a list of boss fights
+    """
+    season = season - 1
+
+    data = cached_session.get(f'{BASE_URL}/fights').json()["data"]
+    if id_:
+        data = list(filter(lambda x: x['id'] == id_, data))
+    if season > 1:
+        data = list(filter(lambda x: x['data']['season'] == season, data))
+
+    return data

--- a/blaseball_mike/models.py
+++ b/blaseball_mike/models.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 import re
 import uuid
 import functools
+import json
 
 from dateutil.parser import parse
 
@@ -964,8 +965,56 @@ class Game(Base):
 
 
 class Fight(Game):
-    """Represents a Blaseball boss fight. Currently unimplemented."""
-    pass  # will probably need this eventually.
+    """Represents a Blaseball boss fight."""
+
+    class DamageResults(Base):
+        """
+        Information regarding a specific damage event
+        """
+        @Base.lazy_load("_dmg_type")
+        def dmg_type(self):
+            return tables.DamageType(self._dmg_type)
+
+        @Base.lazy_load("_player_source_id", cache_name="_player_source")
+        def player_source(self):
+            return Player.load_one(self._player_source_id)
+
+        @Base.lazy_load("_team_target_id", cache_name="_team_target")
+        def team_target(self):
+            return Team.load(self._team_target_id)
+
+    @classmethod
+    def load_by_id(cls, id_):
+        fights = chronicler.get_fights(id_=id_)
+        if len(fights) != 1:
+            return None
+        return cls(fights[0]["data"])
+
+    @classmethod
+    def load_by_season(cls, season):
+        return {
+            x['id']: cls(x["data"]) for x in chronicler.get_fights(season=season)
+        }
+
+    @Base.lazy_load("_away_hp")
+    def away_hp(self):
+        return int(self._away_hp)
+
+    @Base.lazy_load("_home_hp")
+    def home_hp(self):
+        return int(self._home_hp)
+
+    @Base.lazy_load("_away_max_hp")
+    def away_max_hp(self):
+        return int(self._away_max_hp)
+
+    @Base.lazy_load("_home_max_hp")
+    def home_max_hp(self):
+        return int(self._home_max_hp)
+
+    @Base.lazy_load("_damage_results_str", cache_name="_damage_results", default_value=list())
+    def damage_results(self):
+        return [self.DamageResults(x) for x in json.loads(self._damage_results_str)]
 
 
 class DecreeResult(Base):

--- a/blaseball_mike/tables.py
+++ b/blaseball_mike/tables.py
@@ -70,3 +70,40 @@ class Tarot(Enum):
         obj._value_ = keycode
         obj.text = text
         return obj
+
+
+class DamageType(Enum):
+    INVALID = -1
+    STEAL = 0
+    HOME_STEAL = 1
+    RUN = 2
+    HOME_RUN = 3
+    STRIKE = 4
+    FOUL_BALL = 5
+    STRIKE_OUT = 6
+    FLY_OUT = 7
+    GROUND_OUT = 8
+    SINGLE = 9
+    DOUBLE = 10
+    TRIPLE = 11
+    QUADRUPLE = 12
+    WALK = 13
+    CAUGHT_STEALING = 14
+    BALL = 15
+    SACRIFICE_FLY = 16
+    OUT = 17
+    CURSE_OF_CROWS = 18
+    GIVE_SPIRIT = 19
+    BIG_PEANUT = 20
+    BLOOD_DRAIN = 21
+    PEANUT_SWALLOWED = 22
+    INCINERATION = 23
+    FEEDBACK = 24
+    REVERB = 25
+    UNSHELLED = 26
+    PARTYING = 27
+    LOVE_SPELL = 28
+    PEANUT_YUMMY = 29
+    SUPER_PEANUT_YUMMY = 30
+    SUPER_PEANUT_ALLERGIC = 31
+    REBIRTH = 32

--- a/docs/blaseball_mike/chronicler.html
+++ b/docs/blaseball_mike/chronicler.html
@@ -35,6 +35,7 @@ API Reference (out of date): https://astrid.stoplight.io/docs/sibr/reference/Chr
 import requests_cache
 import requests
 from datetime import datetime
+from dateutil.parser import parse
 
 BASE_URL = &#39;https://api.sibr.dev/chronicler/v1&#39;
 TIMESTAMP_FORMAT = &#34;%Y-%m-%dT%H:%M:%S.%fZ&#34;
@@ -164,6 +165,7 @@ def get_tribute_updates(before=None, after=None, order=None, count=None):
 
     return paged_get(f&#39;{BASE_URL}/tributes/hourly&#39;, params=params, session=cached_session)
 
+
 def time_map(season=0, tournament=-1, day=0, include_nongame=False):
     &#34;&#34;&#34;
     Map a season/day to a real-life timestamp
@@ -173,20 +175,41 @@ def time_map(season=0, tournament=-1, day=0, include_nongame=False):
     season = season - 1
     day = day - 1
 
-    map = cached_session.get(f&#39;{BASE_URL}/time/map&#39;).json()
+    map_ = cached_session.get(f&#39;{BASE_URL}/time/map&#39;).json()
 
     # Filter out desired events
     if tournament != -1:
         # Season is not always -1 if a tournament is active, so ignore it
-        results = list(filter(lambda x: x[&#39;tournament&#39;] == tournament and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == tournament and x[&#39;day&#39;] == day, map_[&#39;data&#39;]))
     else:
-        results = list(filter(lambda x: x[&#39;tournament&#39;] == -1 and x[&#39;season&#39;] == season and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == -1 and x[&#39;season&#39;] == season and x[&#39;day&#39;] == day, map_[&#39;data&#39;]))
 
     # Optionally filter out phase-change events
     if not include_nongame:
         results = list(filter(lambda x: x[&#39;type&#39;] in (&#39;season&#39;, &#39;tournament&#39;, &#39;postseason&#39;), results))
 
-    return results</code></pre>
+    # Convert time strings into datetime objects
+    for result in results:
+        result[&#34;startTime&#34;] = parse(result[&#34;startTime&#34;])
+        if result[&#34;endTime&#34;] is not None:
+            result[&#34;endTime&#34;] = parse(result[&#34;endTime&#34;])
+
+    return results
+
+
+def get_fights(id_=None, season=0):
+    &#34;&#34;&#34;
+    Return a list of boss fights
+    &#34;&#34;&#34;
+    season = season - 1
+
+    data = cached_session.get(f&#39;{BASE_URL}/fights&#39;).json()[&#34;data&#34;]
+    if id_:
+        data = list(filter(lambda x: x[&#39;id&#39;] == id_, data))
+    if season &gt; 1:
+        data = list(filter(lambda x: x[&#39;data&#39;][&#39;season&#39;] == season, data))
+
+    return data</code></pre>
 </details>
 </section>
 <section>
@@ -196,6 +219,30 @@ def time_map(season=0, tournament=-1, day=0, include_nongame=False):
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
+<dt id="blaseball_mike.chronicler.get_fights"><code class="name flex">
+<span>def <span class="ident">get_fights</span></span>(<span>id_=None, season=0)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a list of boss fights</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_fights(id_=None, season=0):
+    &#34;&#34;&#34;
+    Return a list of boss fights
+    &#34;&#34;&#34;
+    season = season - 1
+
+    data = cached_session.get(f&#39;{BASE_URL}/fights&#39;).json()[&#34;data&#34;]
+    if id_:
+        data = list(filter(lambda x: x[&#39;id&#39;] == id_, data))
+    if season &gt; 1:
+        data = list(filter(lambda x: x[&#39;data&#39;][&#39;season&#39;] == season, data))
+
+    return data</code></pre>
+</details>
+</dd>
 <dt id="blaseball_mike.chronicler.get_games"><code class="name flex">
 <span>def <span class="ident">get_games</span></span>(<span>season=None, tournament=None, day=None, team_ids=None, pitcher_ids=None, weather=None, started=None, finished=None, outcomes=None, order=None, count=None)</span>
 </code></dt>
@@ -393,18 +440,24 @@ def time_map(season=0, tournament=-1, day=0, include_nongame=False):
     season = season - 1
     day = day - 1
 
-    map = cached_session.get(f&#39;{BASE_URL}/time/map&#39;).json()
+    map_ = cached_session.get(f&#39;{BASE_URL}/time/map&#39;).json()
 
     # Filter out desired events
     if tournament != -1:
         # Season is not always -1 if a tournament is active, so ignore it
-        results = list(filter(lambda x: x[&#39;tournament&#39;] == tournament and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == tournament and x[&#39;day&#39;] == day, map_[&#39;data&#39;]))
     else:
-        results = list(filter(lambda x: x[&#39;tournament&#39;] == -1 and x[&#39;season&#39;] == season and x[&#39;day&#39;] == day, map[&#39;data&#39;]))
+        results = list(filter(lambda x: x[&#39;tournament&#39;] == -1 and x[&#39;season&#39;] == season and x[&#39;day&#39;] == day, map_[&#39;data&#39;]))
 
     # Optionally filter out phase-change events
     if not include_nongame:
         results = list(filter(lambda x: x[&#39;type&#39;] in (&#39;season&#39;, &#39;tournament&#39;, &#39;postseason&#39;), results))
+
+    # Convert time strings into datetime objects
+    for result in results:
+        result[&#34;startTime&#34;] = parse(result[&#34;startTime&#34;])
+        if result[&#34;endTime&#34;] is not None:
+            result[&#34;endTime&#34;] = parse(result[&#34;endTime&#34;])
 
     return results</code></pre>
 </details>
@@ -427,6 +480,7 @@ def time_map(season=0, tournament=-1, day=0, include_nongame=False):
 </li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="two-column">
+<li><code><a title="blaseball_mike.chronicler.get_fights" href="#blaseball_mike.chronicler.get_fights">get_fights</a></code></li>
 <li><code><a title="blaseball_mike.chronicler.get_games" href="#blaseball_mike.chronicler.get_games">get_games</a></code></li>
 <li><code><a title="blaseball_mike.chronicler.get_player_updates" href="#blaseball_mike.chronicler.get_player_updates">get_player_updates</a></code></li>
 <li><code><a title="blaseball_mike.chronicler.get_team_updates" href="#blaseball_mike.chronicler.get_team_updates">get_team_updates</a></code></li>

--- a/docs/blaseball_mike/models.html
+++ b/docs/blaseball_mike/models.html
@@ -47,6 +47,7 @@ from collections import OrderedDict
 import re
 import uuid
 import functools
+import json
 
 from dateutil.parser import parse
 
@@ -998,8 +999,56 @@ class Game(Base):
 
 
 class Fight(Game):
-    &#34;&#34;&#34;Represents a Blaseball boss fight. Currently unimplemented.&#34;&#34;&#34;
-    pass  # will probably need this eventually.
+    &#34;&#34;&#34;Represents a Blaseball boss fight.&#34;&#34;&#34;
+
+    class DamageResults(Base):
+        &#34;&#34;&#34;
+        Information regarding a specific damage event
+        &#34;&#34;&#34;
+        @Base.lazy_load(&#34;_dmg_type&#34;)
+        def dmg_type(self):
+            return tables.DamageType(self._dmg_type)
+
+        @Base.lazy_load(&#34;_player_source_id&#34;, cache_name=&#34;_player_source&#34;)
+        def player_source(self):
+            return Player.load_one(self._player_source_id)
+
+        @Base.lazy_load(&#34;_team_target_id&#34;, cache_name=&#34;_team_target&#34;)
+        def team_target(self):
+            return Team.load(self._team_target_id)
+
+    @classmethod
+    def load_by_id(cls, id_):
+        fights = chronicler.get_fights(id_=id_)
+        if len(fights) != 1:
+            return None
+        return cls(fights[0][&#34;data&#34;])
+
+    @classmethod
+    def load_by_season(cls, season):
+        return {
+            x[&#39;id&#39;]: cls(x[&#34;data&#34;]) for x in chronicler.get_fights(season=season)
+        }
+
+    @Base.lazy_load(&#34;_away_hp&#34;)
+    def away_hp(self):
+        return int(self._away_hp)
+
+    @Base.lazy_load(&#34;_home_hp&#34;)
+    def home_hp(self):
+        return int(self._home_hp)
+
+    @Base.lazy_load(&#34;_away_max_hp&#34;)
+    def away_max_hp(self):
+        return int(self._away_max_hp)
+
+    @Base.lazy_load(&#34;_home_max_hp&#34;)
+    def home_max_hp(self):
+        return int(self._home_max_hp)
+
+    @Base.lazy_load(&#34;_damage_results_str&#34;, cache_name=&#34;_damage_results&#34;, default_value=list())
+    def damage_results(self):
+        return [self.DamageResults(x) for x in json.loads(self._damage_results_str)]
 
 
 class DecreeResult(Base):
@@ -1580,6 +1629,7 @@ property to see what JSON keys have been deserialized.</p></div>
 <li><a title="blaseball_mike.models.Division" href="#blaseball_mike.models.Division">Division</a></li>
 <li><a title="blaseball_mike.models.Election" href="#blaseball_mike.models.Election">Election</a></li>
 <li><a title="blaseball_mike.models.ElectionResult" href="#blaseball_mike.models.ElectionResult">ElectionResult</a></li>
+<li><a title="blaseball_mike.models.Fight.DamageResults" href="#blaseball_mike.models.Fight.DamageResults">Fight.DamageResults</a></li>
 <li><a title="blaseball_mike.models.Game" href="#blaseball_mike.models.Game">Game</a></li>
 <li><a title="blaseball_mike.models.GameStatsheet" href="#blaseball_mike.models.GameStatsheet">GameStatsheet</a></li>
 <li><a title="blaseball_mike.models.GlobalEvent" href="#blaseball_mike.models.GlobalEvent">GlobalEvent</a></li>
@@ -2358,14 +2408,62 @@ def tiding_results(self):
 <span>(</span><span>data)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Represents a Blaseball boss fight. Currently unimplemented.</p></div>
+<div class="desc"><p>Represents a Blaseball boss fight.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class Fight(Game):
-    &#34;&#34;&#34;Represents a Blaseball boss fight. Currently unimplemented.&#34;&#34;&#34;
-    pass  # will probably need this eventually.</code></pre>
+    &#34;&#34;&#34;Represents a Blaseball boss fight.&#34;&#34;&#34;
+
+    class DamageResults(Base):
+        &#34;&#34;&#34;
+        Information regarding a specific damage event
+        &#34;&#34;&#34;
+        @Base.lazy_load(&#34;_dmg_type&#34;)
+        def dmg_type(self):
+            return tables.DamageType(self._dmg_type)
+
+        @Base.lazy_load(&#34;_player_source_id&#34;, cache_name=&#34;_player_source&#34;)
+        def player_source(self):
+            return Player.load_one(self._player_source_id)
+
+        @Base.lazy_load(&#34;_team_target_id&#34;, cache_name=&#34;_team_target&#34;)
+        def team_target(self):
+            return Team.load(self._team_target_id)
+
+    @classmethod
+    def load_by_id(cls, id_):
+        fights = chronicler.get_fights(id_=id_)
+        if len(fights) != 1:
+            return None
+        return cls(fights[0][&#34;data&#34;])
+
+    @classmethod
+    def load_by_season(cls, season):
+        return {
+            x[&#39;id&#39;]: cls(x[&#34;data&#34;]) for x in chronicler.get_fights(season=season)
+        }
+
+    @Base.lazy_load(&#34;_away_hp&#34;)
+    def away_hp(self):
+        return int(self._away_hp)
+
+    @Base.lazy_load(&#34;_home_hp&#34;)
+    def home_hp(self):
+        return int(self._home_hp)
+
+    @Base.lazy_load(&#34;_away_max_hp&#34;)
+    def away_max_hp(self):
+        return int(self._away_max_hp)
+
+    @Base.lazy_load(&#34;_home_max_hp&#34;)
+    def home_max_hp(self):
+        return int(self._home_max_hp)
+
+    @Base.lazy_load(&#34;_damage_results_str&#34;, cache_name=&#34;_damage_results&#34;, default_value=list())
+    def damage_results(self):
+        return [self.DamageResults(x) for x in json.loads(self._damage_results_str)]</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -2373,6 +2471,33 @@ def tiding_results(self):
 <li><a title="blaseball_mike.models.Base" href="#blaseball_mike.models.Base">Base</a></li>
 <li>abc.ABC</li>
 </ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="blaseball_mike.models.Fight.DamageResults"><code class="name">var <span class="ident">DamageResults</span></code></dt>
+<dd>
+<div class="desc"><p>Information regarding a specific damage event</p></div>
+</dd>
+<dt id="blaseball_mike.models.Fight.away_hp"><code class="name">var <span class="ident">away_hp</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.models.Fight.away_max_hp"><code class="name">var <span class="ident">away_max_hp</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.models.Fight.damage_results"><code class="name">var <span class="ident">damage_results</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.models.Fight.home_hp"><code class="name">var <span class="ident">home_hp</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.models.Fight.home_max_hp"><code class="name">var <span class="ident">home_max_hp</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="blaseball_mike.models.Game" href="#blaseball_mike.models.Game">Game</a></b></code>:
@@ -6318,6 +6443,14 @@ def player(self):
 </li>
 <li>
 <h4><code><a title="blaseball_mike.models.Fight" href="#blaseball_mike.models.Fight">Fight</a></code></h4>
+<ul class="two-column">
+<li><code><a title="blaseball_mike.models.Fight.DamageResults" href="#blaseball_mike.models.Fight.DamageResults">DamageResults</a></code></li>
+<li><code><a title="blaseball_mike.models.Fight.away_hp" href="#blaseball_mike.models.Fight.away_hp">away_hp</a></code></li>
+<li><code><a title="blaseball_mike.models.Fight.away_max_hp" href="#blaseball_mike.models.Fight.away_max_hp">away_max_hp</a></code></li>
+<li><code><a title="blaseball_mike.models.Fight.damage_results" href="#blaseball_mike.models.Fight.damage_results">damage_results</a></code></li>
+<li><code><a title="blaseball_mike.models.Fight.home_hp" href="#blaseball_mike.models.Fight.home_hp">home_hp</a></code></li>
+<li><code><a title="blaseball_mike.models.Fight.home_max_hp" href="#blaseball_mike.models.Fight.home_max_hp">home_max_hp</a></code></li>
+</ul>
 </li>
 <li>
 <h4><code><a title="blaseball_mike.models.Game" href="#blaseball_mike.models.Game">Game</a></code></h4>

--- a/docs/blaseball_mike/tables.html
+++ b/docs/blaseball_mike/tables.html
@@ -98,7 +98,44 @@ class Tarot(Enum):
         obj = object.__new__(cls)
         obj._value_ = keycode
         obj.text = text
-        return obj</code></pre>
+        return obj
+
+
+class DamageType(Enum):
+    INVALID = -1
+    STEAL = 0
+    HOME_STEAL = 1
+    RUN = 2
+    HOME_RUN = 3
+    STRIKE = 4
+    FOUL_BALL = 5
+    STRIKE_OUT = 6
+    FLY_OUT = 7
+    GROUND_OUT = 8
+    SINGLE = 9
+    DOUBLE = 10
+    TRIPLE = 11
+    QUADRUPLE = 12
+    WALK = 13
+    CAUGHT_STEALING = 14
+    BALL = 15
+    SACRIFICE_FLY = 16
+    OUT = 17
+    CURSE_OF_CROWS = 18
+    GIVE_SPIRIT = 19
+    BIG_PEANUT = 20
+    BLOOD_DRAIN = 21
+    PEANUT_SWALLOWED = 22
+    INCINERATION = 23
+    FEEDBACK = 24
+    REVERB = 25
+    UNSHELLED = 26
+    PARTYING = 27
+    LOVE_SPELL = 28
+    PEANUT_YUMMY = 29
+    SUPER_PEANUT_YUMMY = 30
+    SUPER_PEANUT_ALLERGIC = 31
+    REBIRTH = 32</code></pre>
 </details>
 </section>
 <section>
@@ -110,6 +147,196 @@ class Tarot(Enum):
 <section>
 <h2 class="section-title" id="header-classes">Classes</h2>
 <dl>
+<dt id="blaseball_mike.tables.DamageType"><code class="flex name class">
+<span>class <span class="ident">DamageType</span></span>
+<span>(</span><span>value, names=None, *, module=None, qualname=None, type=None, start=1)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>An enumeration.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class DamageType(Enum):
+    INVALID = -1
+    STEAL = 0
+    HOME_STEAL = 1
+    RUN = 2
+    HOME_RUN = 3
+    STRIKE = 4
+    FOUL_BALL = 5
+    STRIKE_OUT = 6
+    FLY_OUT = 7
+    GROUND_OUT = 8
+    SINGLE = 9
+    DOUBLE = 10
+    TRIPLE = 11
+    QUADRUPLE = 12
+    WALK = 13
+    CAUGHT_STEALING = 14
+    BALL = 15
+    SACRIFICE_FLY = 16
+    OUT = 17
+    CURSE_OF_CROWS = 18
+    GIVE_SPIRIT = 19
+    BIG_PEANUT = 20
+    BLOOD_DRAIN = 21
+    PEANUT_SWALLOWED = 22
+    INCINERATION = 23
+    FEEDBACK = 24
+    REVERB = 25
+    UNSHELLED = 26
+    PARTYING = 27
+    LOVE_SPELL = 28
+    PEANUT_YUMMY = 29
+    SUPER_PEANUT_YUMMY = 30
+    SUPER_PEANUT_ALLERGIC = 31
+    REBIRTH = 32</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>enum.Enum</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="blaseball_mike.tables.DamageType.BALL"><code class="name">var <span class="ident">BALL</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.BIG_PEANUT"><code class="name">var <span class="ident">BIG_PEANUT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.BLOOD_DRAIN"><code class="name">var <span class="ident">BLOOD_DRAIN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.CAUGHT_STEALING"><code class="name">var <span class="ident">CAUGHT_STEALING</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.CURSE_OF_CROWS"><code class="name">var <span class="ident">CURSE_OF_CROWS</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.DOUBLE"><code class="name">var <span class="ident">DOUBLE</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.FEEDBACK"><code class="name">var <span class="ident">FEEDBACK</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.FLY_OUT"><code class="name">var <span class="ident">FLY_OUT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.FOUL_BALL"><code class="name">var <span class="ident">FOUL_BALL</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.GIVE_SPIRIT"><code class="name">var <span class="ident">GIVE_SPIRIT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.GROUND_OUT"><code class="name">var <span class="ident">GROUND_OUT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.HOME_RUN"><code class="name">var <span class="ident">HOME_RUN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.HOME_STEAL"><code class="name">var <span class="ident">HOME_STEAL</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.INCINERATION"><code class="name">var <span class="ident">INCINERATION</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.INVALID"><code class="name">var <span class="ident">INVALID</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.LOVE_SPELL"><code class="name">var <span class="ident">LOVE_SPELL</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.OUT"><code class="name">var <span class="ident">OUT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.PARTYING"><code class="name">var <span class="ident">PARTYING</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.PEANUT_SWALLOWED"><code class="name">var <span class="ident">PEANUT_SWALLOWED</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.PEANUT_YUMMY"><code class="name">var <span class="ident">PEANUT_YUMMY</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.QUADRUPLE"><code class="name">var <span class="ident">QUADRUPLE</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.REBIRTH"><code class="name">var <span class="ident">REBIRTH</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.REVERB"><code class="name">var <span class="ident">REVERB</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.RUN"><code class="name">var <span class="ident">RUN</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.SACRIFICE_FLY"><code class="name">var <span class="ident">SACRIFICE_FLY</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.SINGLE"><code class="name">var <span class="ident">SINGLE</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.STEAL"><code class="name">var <span class="ident">STEAL</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.STRIKE"><code class="name">var <span class="ident">STRIKE</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.STRIKE_OUT"><code class="name">var <span class="ident">STRIKE_OUT</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.SUPER_PEANUT_ALLERGIC"><code class="name">var <span class="ident">SUPER_PEANUT_ALLERGIC</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.SUPER_PEANUT_YUMMY"><code class="name">var <span class="ident">SUPER_PEANUT_YUMMY</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.TRIPLE"><code class="name">var <span class="ident">TRIPLE</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.UNSHELLED"><code class="name">var <span class="ident">UNSHELLED</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="blaseball_mike.tables.DamageType.WALK"><code class="name">var <span class="ident">WALK</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</dd>
 <dt id="blaseball_mike.tables.Tarot"><code class="flex name class">
 <span>class <span class="ident">Tarot</span></span>
 <span>(</span><span>value, names=None, *, module=None, qualname=None, type=None, start=1)</span>
@@ -390,6 +617,45 @@ class Tarot(Enum):
 </li>
 <li><h3><a href="#header-classes">Classes</a></h3>
 <ul>
+<li>
+<h4><code><a title="blaseball_mike.tables.DamageType" href="#blaseball_mike.tables.DamageType">DamageType</a></code></h4>
+<ul class="">
+<li><code><a title="blaseball_mike.tables.DamageType.BALL" href="#blaseball_mike.tables.DamageType.BALL">BALL</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.BIG_PEANUT" href="#blaseball_mike.tables.DamageType.BIG_PEANUT">BIG_PEANUT</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.BLOOD_DRAIN" href="#blaseball_mike.tables.DamageType.BLOOD_DRAIN">BLOOD_DRAIN</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.CAUGHT_STEALING" href="#blaseball_mike.tables.DamageType.CAUGHT_STEALING">CAUGHT_STEALING</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.CURSE_OF_CROWS" href="#blaseball_mike.tables.DamageType.CURSE_OF_CROWS">CURSE_OF_CROWS</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.DOUBLE" href="#blaseball_mike.tables.DamageType.DOUBLE">DOUBLE</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.FEEDBACK" href="#blaseball_mike.tables.DamageType.FEEDBACK">FEEDBACK</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.FLY_OUT" href="#blaseball_mike.tables.DamageType.FLY_OUT">FLY_OUT</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.FOUL_BALL" href="#blaseball_mike.tables.DamageType.FOUL_BALL">FOUL_BALL</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.GIVE_SPIRIT" href="#blaseball_mike.tables.DamageType.GIVE_SPIRIT">GIVE_SPIRIT</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.GROUND_OUT" href="#blaseball_mike.tables.DamageType.GROUND_OUT">GROUND_OUT</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.HOME_RUN" href="#blaseball_mike.tables.DamageType.HOME_RUN">HOME_RUN</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.HOME_STEAL" href="#blaseball_mike.tables.DamageType.HOME_STEAL">HOME_STEAL</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.INCINERATION" href="#blaseball_mike.tables.DamageType.INCINERATION">INCINERATION</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.INVALID" href="#blaseball_mike.tables.DamageType.INVALID">INVALID</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.LOVE_SPELL" href="#blaseball_mike.tables.DamageType.LOVE_SPELL">LOVE_SPELL</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.OUT" href="#blaseball_mike.tables.DamageType.OUT">OUT</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.PARTYING" href="#blaseball_mike.tables.DamageType.PARTYING">PARTYING</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.PEANUT_SWALLOWED" href="#blaseball_mike.tables.DamageType.PEANUT_SWALLOWED">PEANUT_SWALLOWED</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.PEANUT_YUMMY" href="#blaseball_mike.tables.DamageType.PEANUT_YUMMY">PEANUT_YUMMY</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.QUADRUPLE" href="#blaseball_mike.tables.DamageType.QUADRUPLE">QUADRUPLE</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.REBIRTH" href="#blaseball_mike.tables.DamageType.REBIRTH">REBIRTH</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.REVERB" href="#blaseball_mike.tables.DamageType.REVERB">REVERB</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.RUN" href="#blaseball_mike.tables.DamageType.RUN">RUN</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.SACRIFICE_FLY" href="#blaseball_mike.tables.DamageType.SACRIFICE_FLY">SACRIFICE_FLY</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.SINGLE" href="#blaseball_mike.tables.DamageType.SINGLE">SINGLE</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.STEAL" href="#blaseball_mike.tables.DamageType.STEAL">STEAL</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.STRIKE" href="#blaseball_mike.tables.DamageType.STRIKE">STRIKE</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.STRIKE_OUT" href="#blaseball_mike.tables.DamageType.STRIKE_OUT">STRIKE_OUT</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.SUPER_PEANUT_ALLERGIC" href="#blaseball_mike.tables.DamageType.SUPER_PEANUT_ALLERGIC">SUPER_PEANUT_ALLERGIC</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.SUPER_PEANUT_YUMMY" href="#blaseball_mike.tables.DamageType.SUPER_PEANUT_YUMMY">SUPER_PEANUT_YUMMY</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.TRIPLE" href="#blaseball_mike.tables.DamageType.TRIPLE">TRIPLE</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.UNSHELLED" href="#blaseball_mike.tables.DamageType.UNSHELLED">UNSHELLED</a></code></li>
+<li><code><a title="blaseball_mike.tables.DamageType.WALK" href="#blaseball_mike.tables.DamageType.WALK">WALK</a></code></li>
+</ul>
+</li>
 <li>
 <h4><code><a title="blaseball_mike.tables.Tarot" href="#blaseball_mike.tables.Tarot">Tarot</a></code></h4>
 <ul class="two-column">


### PR DESCRIPTION
Decodes the boss fights, with data on previous fights pulled from the chronicler endpoint. Some notes:
* This json decodes the `damageResults` string to generate a list of DamageResult objects for further inspection. This currently uses the standard library's `json` module, if you want I can use `ujson` like the event stream stuff
* Team based fields can error, because all the boss fights so far have involved the PODS which no longer exist in the blaseball API. We could swap over the Team load calls to chronicler to fix this if you think it's important