### PR TITLE
Dynamically get field names when generating documentation

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -33,7 +33,7 @@ jobs:
           pip install -r requirements.txt
           pip install pdoc3
       - name: Generate Docs
-        run: pdoc --html blaseball_mike --force -o docs
+        run: python make_docs.py
       - name: Deploy docs
         uses: Cecilapp/GitHub-Pages-deploy@3.1.0
         env:

--- a/blaseball_mike/__init__.py
+++ b/blaseball_mike/__init__.py
@@ -1,0 +1,15 @@
+"""
+`blaseball-mike` is a python library for accessing Blaseball API data,
+over the main public API and various fan-created archives and databases.
+This includes player/team/game fetches, as well as deserialization of
+the live event stream.
+
+>>> from blaseball_mike.models import Team
+>>> fridays = Team.load_by_name('fridays')
+>>> [player.name for player in fridays.lineup]
+['Elijah Valenzuela', 'Juice Collins', 'York Silk', 'Baldwin Breadwinner', 'Terrell Bradley', 'Sixpack Dogwalker', 'Fletcher Yamamoto', 'Bevan Underbuck', 'Christian Combs']
+
+Nested objects will autoload when iterated over. Attributes match the
+names found in the official Blaseball API, just in snake case. Derived
+spec can be found [here](https://github.com/Society-for-Internet-Blaseball-Research/blaseball-api-spec).
+"""

--- a/blaseball_mike/models/election.py
+++ b/blaseball_mike/models/election.py
@@ -7,6 +7,11 @@ class Election(Base):
     """Represents the current election"""
 
     @classmethod
+    def _get_fields(cls):
+        p = cls.load()
+        return [cls._from_api_conversion(x) for x in p.fields]
+
+    @classmethod
     def load(cls):
         """Load the current election"""
         offseason = database.get_offseason_election_details()
@@ -18,6 +23,10 @@ OffseasonSetup = Election
 
 class ElectionResult(Base):
     """Represents the results of an election"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_by_season(11)
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load_by_season(cls, season):
@@ -61,6 +70,10 @@ OffseasonResult = ElectionResult
 
 class DecreeResult(Base):
     """Represents the results of a single decree."""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("643280fc-b7c6-4b6d-a164-9b53e1a3e47a")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, *ids):
@@ -82,6 +95,10 @@ class DecreeResult(Base):
 
 class BlessingResult(Base):
     """Represents the results of a single blessing"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("cbb567c0-d770-4d22-92f6-ff16ebb94758")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, *ids):
@@ -127,6 +144,10 @@ class BlessingResult(Base):
 
 class TidingResult(Base):
     """Represents the results of a single election tiding"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("future_written")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, *ids):

--- a/blaseball_mike/models/fight.py
+++ b/blaseball_mike/models/fight.py
@@ -9,6 +9,10 @@ from .. import tables, chronicler
 
 class Fight(Game):
     """Represents a Blaseball boss fight."""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_by_id("6754f45d-52a6-4b2f-b63c-15dcd520f8cf")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     class DamageResults(Base):
         """

--- a/blaseball_mike/models/game.py
+++ b/blaseball_mike/models/game.py
@@ -10,6 +10,10 @@ class Game(Base):
     """
     Represents one blaseball game
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_by_id("1cbd9d82-89e6-46b2-9082-815f59e1a130")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load_by_id(cls, id_):

--- a/blaseball_mike/models/global_event.py
+++ b/blaseball_mike/models/global_event.py
@@ -8,6 +8,12 @@ class GlobalEvent(Base):
     """
     Represents one global event, ie the events used to populate the ticker.
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load()
+        if len(p) < 1:
+            return []
+        return [cls._from_api_conversion(x) for x in p[0].fields]
 
     @classmethod
     def load(cls):

--- a/blaseball_mike/models/item.py
+++ b/blaseball_mike/models/item.py
@@ -5,6 +5,10 @@ from .. import database
 
 class Item(Base):
     """Represents an single item, such as a bat or armor"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("GUNBLADE_A")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, *ids):

--- a/blaseball_mike/models/leaderboard.py
+++ b/blaseball_mike/models/leaderboard.py
@@ -9,6 +9,10 @@ from .. import database, chronicler
 
 class Idol(Base):
     """Represents a single idol board player"""
+    @classmethod
+    def _get_fields(cls):
+        p = list(cls.load().values())[0]
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls):
@@ -30,6 +34,10 @@ class Idol(Base):
 
 class Tribute(Base):
     """Represents a single tribute recipient on the hall of flame"""
+    @classmethod
+    def _get_fields(cls):
+        p = list(cls.load().values())[0]
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls):

--- a/blaseball_mike/models/league.py
+++ b/blaseball_mike/models/league.py
@@ -9,6 +9,10 @@ class League(Base):
     """
     Represents the entire league
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load()
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     def __init__(self, data):
         super().__init__(data)
@@ -44,6 +48,10 @@ class Subleague(Base):
     """
     Represents a subleague, ie Mild vs Wild
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load("4fe65afa-804f-4bb2-9b15-1281b2eab110")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     def __init__(self, data):
         super().__init__(data)
@@ -74,6 +82,10 @@ class Division(Base):
     """
     Represents a blaseball division ie Mild Low, Mild High, Wild Low, Wild High.
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load("f711d960-dc28-4ae2-9249-e1f320fec7d7")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, id_):
@@ -114,6 +126,10 @@ class Division(Base):
 
 class Tiebreaker(Base):
     """Represents a league's tiebreaker order"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("370c436f-79fa-418b-bc98-5db48442ba3f")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, id_):
@@ -121,6 +137,10 @@ class Tiebreaker(Base):
         return {
             id_: cls(tiebreaker) for (id_, tiebreaker) in tiebreakers.items()
         }
+
+    @classmethod
+    def load_one(cls, id_):
+        return cls.load(id_).get(id_)
 
     @Base.lazy_load("_order_ids", cache_name="_order", default_value=OrderedDict())
     def order(self):

--- a/blaseball_mike/models/modification.py
+++ b/blaseball_mike/models/modification.py
@@ -4,6 +4,10 @@ from .. import database
 
 class Modification(Base):
     """Represents a player or team modification"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("FIREPROOF")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, *ids):

--- a/blaseball_mike/models/player.py
+++ b/blaseball_mike/models/player.py
@@ -14,6 +14,10 @@ class Player(Base):
     """
     Represents a blaseball player.
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("766dfd1e-11c3-42b6-a167-9b2d568b5dc0")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, *ids):

--- a/blaseball_mike/models/playoff.py
+++ b/blaseball_mike/models/playoff.py
@@ -6,6 +6,10 @@ from .. import database
 
 class Playoff(Base):
     """Represents a playoff bracket"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_by_season(11)
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load_by_season(cls, season):
@@ -37,6 +41,10 @@ class Playoff(Base):
 
 class PlayoffRound(Base):
     """Represents a round of playoff games"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load("34c99cbf-1d7d-4715-8957-8abcba3c5b89")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, id_):
@@ -87,6 +95,10 @@ class PlayoffRound(Base):
 
 class PlayoffMatchup(Base):
     """Represents a matchup information of teams in a playoff"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load_one("bee2a1e6-50d6-4866-a7b4-f13705873052")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, *ids_):

--- a/blaseball_mike/models/season.py
+++ b/blaseball_mike/models/season.py
@@ -6,6 +6,10 @@ from .. import database
 
 class Season(Base):
     """Represents an individual season"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load(11)
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, season_number):
@@ -32,6 +36,10 @@ class Season(Base):
 
 class Standings(Base):
     """Represents the team standings"""
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load("dbcb0a13-2d59-4f13-8681-fd969aefdcc6")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, id_):

--- a/blaseball_mike/models/simulation_data.py
+++ b/blaseball_mike/models/simulation_data.py
@@ -9,6 +9,10 @@ class SimulationData(Base):
     """
     Represents the current simulation state.
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load()
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls):

--- a/blaseball_mike/models/statsheet.py
+++ b/blaseball_mike/models/statsheet.py
@@ -5,6 +5,11 @@ from .. import database
 
 
 class PlayerStatsheet(Base):
+    @classmethod
+    def _get_fields(cls):
+        id_ = "e80b9497-c604-456d-9bee-c860d4759b14"
+        p = cls.load(id_).get(id_)
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, ids):
@@ -16,6 +21,11 @@ class PlayerStatsheet(Base):
 
 
 class TeamStatsheet(Base):
+    @classmethod
+    def _get_fields(cls):
+        id_ = "07b2b5bf-9eeb-4eff-9be9-d0f66c687f76"
+        p = cls.load(id_).get(id_)
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, ids):
@@ -31,6 +41,11 @@ class TeamStatsheet(Base):
 
 
 class GameStatsheet(Base):
+    @classmethod
+    def _get_fields(cls):
+        id_ = "f852abec-b80e-40e2-b213-f0368d4e7f57"
+        p = cls.load(id_).get(id_)
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, ids):
@@ -77,6 +92,11 @@ class GameStatsheet(Base):
 
 
 class SeasonStatsheet(Base):
+    @classmethod
+    def _get_fields(cls):
+        id_ = "64392ad5-e14c-42c0-825c-c85da29addaa"
+        p = cls.load(id_).get(id_)
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, ids):

--- a/blaseball_mike/models/team.py
+++ b/blaseball_mike/models/team.py
@@ -10,6 +10,10 @@ class Team(Base):
     """
     Represents a blaseball team.
     """
+    @classmethod
+    def _get_fields(cls):
+        p = cls.load("8d87c468-699a-47a8-b40d-cfb73a5660ad")
+        return [cls._from_api_conversion(x) for x in p.fields]
 
     @classmethod
     def load(cls, id_):

--- a/make_docs.py
+++ b/make_docs.py
@@ -1,0 +1,50 @@
+import pdoc
+import os
+import os.path as path
+import re
+from blaseball_mike.models.base import Base
+
+output_dir = 'docs'
+
+
+def recurse_modules(mod):
+    yield mod
+    for submod in mod.submodules():
+        yield from recurse_modules(submod)
+
+
+def recursive_write_files(m):
+    filepath = path.join(output_dir, m.url())
+
+    dirpath = path.dirname(filepath)
+    if not os.access(dirpath, os.R_OK):
+        os.makedirs(dirpath)
+
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write(m.html())
+
+    for submodule in m.submodules():
+        recursive_write_files(submodule)
+
+
+# Generate documentation
+mike_module = pdoc.Module('blaseball_mike')
+
+# Dynamically pull fields for models and add them to the documentation
+for module in recurse_modules(mike_module):
+    for class_ in module.classes():
+        if Base not in [x.obj for x in class_.mro()]:
+            continue
+
+        try:
+            fields = class_.obj._get_fields()
+        except AttributeError:
+            continue
+
+        for field in fields:
+            if field in class_.doc:
+                continue
+            class_.doc[field] = pdoc.Variable(field, module, "", cls=class_, instance_var=True)
+
+# Write to files
+recursive_write_files(mike_module)


### PR DESCRIPTION
This uses a script to generate the [pdoc3 documentation](https://pdoc3.github.io/pdoc/doc/pdoc/index.html#programmatic-usage) rather than the included cli script, so we can iterate over the models and get field names.

closes #83 