### PR TITLE
Add Fool to Tarot in tables.py

### DIFF
--- a/blaseball_mike/tables.py
+++ b/blaseball_mike/tables.py
@@ -41,7 +41,8 @@ class Weather(Enum):
 
 
 class Tarot(Enum):
-    INVALID = -1, "----"
+    INVALID = -2, "----"
+    FOOL = -1, "Fool"
     MAGICIAN = 0, "I The Magician"
     HIGH_PRIESTESS = 1, "II The High Priestess"
     EMPRESS = 2, "III The Empress"


### PR DESCRIPTION
I am also open to removing `INVALID` and making `_missing_` return `FOOL`, or removing both `INVALID` and `_missing_` and considering the enum complete, a la `StatType`

I'm not sure if maintaining `Tarot.INVALID` is necessary, or if that was just added this way to support the (then presumably placeholder) values of the Coffee Cup teams. I'm also not even sure it's fair to say that a team like e.g. The Data Witches have the Fool as a tarot card, or even whether any of this will be relevant ever again with the current Reader v Coin happenings.

All that said, -1 is not an invalid value for the tarot attribute, all breach teams have -1 as their tarot value and the Fool as their card.